### PR TITLE
Replaces Goldify Playlist creation alerts with a popup the user must click through

### DIFF
--- a/src/__tests__/solo/goldify-playlist/GoldifyCreatePlaylist.test.js
+++ b/src/__tests__/solo/goldify-playlist/GoldifyCreatePlaylist.test.js
@@ -34,75 +34,45 @@ const createdPlaylist = playlistFixtures.createGoldifyPlaylist(
   GOLDIFY_PLAYLIST_DESCRIPTION
 );
 
-test("Test GoldifyCreatePlaylist with and without required props", async () => {
-  const wrapper = shallow(
+const createGoldifyPlaylistWrapper = () => {
+  return shallow(
     <GoldifyCreatePlaylist
       retrievedTokenData={{}}
-      userData={{}}
+      userData={{
+        id: userInfoFixtures.getUserTestData().id,
+      }}
       playlistUpdater={jest.fn()}
     />
   );
-  wrapper.instance().createNewGoldifyPlaylist = jest.fn();
-  wrapper.instance().componentDidMount();
-  expect(wrapper.instance().createNewGoldifyPlaylist).not.toHaveBeenCalled();
-
-  wrapper.setProps({
-    retrievedTokenData: goldifySoloFixtures.getTokensTestData(),
-  });
-  wrapper.instance().componentDidMount();
-  expect(wrapper.instance().createNewGoldifyPlaylist).not.toHaveBeenCalled();
-
-  wrapper.setProps({
-    userData: userInfoFixtures.getUserTestData(),
-  });
-  wrapper.instance().componentDidMount();
-  expect(wrapper.instance().createNewGoldifyPlaylist).toHaveBeenCalledTimes(1);
-  expect(wrapper.instance().createNewGoldifyPlaylist).toHaveBeenCalledWith(
-    goldifySoloFixtures.getTokensTestData(),
-    userInfoFixtures.getUserTestData().id
-  );
-});
+};
 
 test("Test functionality: createNewGoldifyPlaylist", async () => {
   createGoldifyPlaylist.mockImplementation(() =>
     Promise.resolve(createdPlaylist)
   );
   uploadPlaylistImage.mockImplementation(() => Promise.resolve(null));
-  jest.spyOn(window, "alert").mockImplementation(() => {});
 
-  const wrapper = shallow(
-    <GoldifyCreatePlaylist
-      retrievedTokenData={{}}
-      userData={{}}
-      playlistUpdater={jest.fn()}
-    />
-  );
+  const wrapper = createGoldifyPlaylistWrapper();
+  wrapper.instance().handlePlaylistCreated = jest.fn();
   await wrapper
     .instance()
     .createNewGoldifyPlaylist(
       goldifySoloFixtures.getTokensTestData(),
       userInfoFixtures.getUserTestData().id
     );
-  expect(alert).toHaveBeenCalledTimes(1);
-  // Upload image after playlist is created
-  expect(uploadPlaylistImage).toHaveBeenCalledTimes(1);
-  expect(wrapper.instance().props.playlistUpdater).toHaveBeenCalledTimes(1);
-  expect(wrapper.instance().props.playlistUpdater).toHaveBeenCalledWith(
+  expect(wrapper.instance().handlePlaylistCreated).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().handlePlaylistCreated).toHaveBeenCalledWith(
     createdPlaylist
   );
+  // Upload image after playlist is created
+  expect(uploadPlaylistImage).toHaveBeenCalledTimes(1);
 });
 
 test("Expect alert, home page when running createGoldifyPlaylist with bad data", async () => {
   createGoldifyPlaylist.mockImplementation(() => Promise.resolve(null));
   jest.spyOn(window, "alert").mockImplementation(() => {});
 
-  const wrapper = shallow(
-    <GoldifyCreatePlaylist
-      retrievedTokenData={{}}
-      userData={{}}
-      playlistUpdater={jest.fn()}
-    />
-  );
+  const wrapper = createGoldifyPlaylistWrapper();
   await wrapper
     .instance()
     .createNewGoldifyPlaylist(
@@ -117,15 +87,92 @@ test("Expect alert, home page when running createGoldifyPlaylist with bad data",
 });
 
 test("Check for which div is loaded on render for createGoldifyPlaylist", () => {
-  const wrapper = shallow(
-    <GoldifyCreatePlaylist
-      retrievedTokenData={{}}
-      userData={{}}
-      playlistUpdater={jest.fn()}
-    />
-  );
+  const wrapper = createGoldifyPlaylistWrapper();
   wrapper.instance().createPlaylistDiv = jest
     .fn()
     .mockReturnValue("Creating Goldify Playlist!");
   expect(wrapper.instance().render()).toEqual("Creating Goldify Playlist!");
+});
+
+test("Check for elements based on loading and success state", () => {
+  const wrapper = createGoldifyPlaylistWrapper();
+
+  wrapper.instance().state = {
+    loading: false,
+    success: false,
+  };
+  let createPlaylistDivString = JSON.stringify(
+    wrapper.instance().createPlaylistDiv()
+  );
+  expect(createPlaylistDivString).toContain("Create Goldify Playlist");
+
+  wrapper.instance().state = {
+    loading: true,
+    success: false,
+  };
+  createPlaylistDivString = JSON.stringify(
+    wrapper.instance().createPlaylistDiv()
+  );
+  expect(createPlaylistDivString).not.toContain("Create Goldify Playlist");
+
+  wrapper.instance().state = {
+    loading: false,
+    success: true,
+  };
+  createPlaylistDivString = JSON.stringify(
+    wrapper.instance().createPlaylistDiv()
+  );
+  expect(createPlaylistDivString).not.toContain("Create Goldify Playlist");
+});
+
+test("Confirm createNewGoldifyPlaylistAction calls createNewGoldifyPlaylist", () => {
+  const wrapper = createGoldifyPlaylistWrapper();
+  wrapper.instance().createNewGoldifyPlaylist = jest.fn();
+  wrapper.instance().createNewGoldifyPlaylistAction();
+  expect(wrapper.instance().createNewGoldifyPlaylist).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().createNewGoldifyPlaylist).toHaveBeenCalledWith(
+    {},
+    userInfoFixtures.getUserTestData().id
+  );
+});
+
+test("Confirm handleButtonClick sets state to loading, then calls createNewGoldifyPlaylistAction", () => {
+  const wrapper = createGoldifyPlaylistWrapper();
+  wrapper.instance().setState = jest.fn();
+  wrapper.instance().createNewGoldifyPlaylistAction = jest.fn();
+
+  wrapper.instance().state.loading = true;
+  wrapper.instance().handleButtonClick();
+  expect(wrapper.instance().setState).not.toHaveBeenCalled();
+  expect(
+    wrapper.instance().createNewGoldifyPlaylistAction
+  ).not.toHaveBeenCalled();
+
+  wrapper.instance().state.loading = false;
+  wrapper.instance().handleButtonClick();
+  expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().setState).toHaveBeenCalledWith({
+    loading: true,
+    success: false,
+  });
+  expect(
+    wrapper.instance().createNewGoldifyPlaylistAction
+  ).toHaveBeenCalledTimes(1);
+});
+
+test("Confirm handlePlaylistCreated calls correct window timeouts and state is set to success", () => {
+  jest.useFakeTimers();
+  const wrapper = createGoldifyPlaylistWrapper();
+  wrapper.instance().setState = jest.fn();
+  wrapper.instance().handlePlaylistCreated({});
+  jest.advanceTimersByTime(2000);
+  expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().setState).toHaveBeenCalledWith({
+    loading: false,
+    success: true,
+  });
+  expect(wrapper.instance().props.playlistUpdater).not.toHaveBeenCalled();
+  jest.advanceTimersByTime(1500);
+  expect(wrapper.instance().props.playlistUpdater).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().props.playlistUpdater).toHaveBeenCalledWith({});
 });

--- a/src/__tests__/solo/goldify-playlist/GoldifyPlaylist.test.js
+++ b/src/__tests__/solo/goldify-playlist/GoldifyPlaylist.test.js
@@ -76,10 +76,14 @@ test("Expect alert when running retrieveGoldifyPlaylist with no Goldify Playlist
   jest.spyOn(window, "alert").mockImplementation(() => {});
 
   const wrapper = goldifyPlaylistWrapper();
+  wrapper.instance().setState = jest.fn();
   await wrapper
     .instance()
     .retrieveGoldifyPlaylist(goldifySoloFixtures.getTokensTestData());
-  expect(alert).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().setState).toHaveBeenCalledWith({
+    goldifyPlaylist: null,
+  });
 });
 
 test("Expect home page to load when running retrieveGoldifyPlaylist with bad data", async () => {

--- a/src/css/GoldifyCreatePlaylist.css
+++ b/src/css/GoldifyCreatePlaylist.css
@@ -1,0 +1,49 @@
+.create-playlist-wrapper {
+  background-color: #0B162A;
+  padding: 10px;
+  margin: 5% auto;
+  box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.4);
+  border-radius: 20px;
+  border: 4px solid #FCC201;
+}
+
+.create-playlist-header {
+  color: #FCC201;
+  margin-bottom: 0;
+}
+
+.create-playlist-body {
+  color: #FCC201;
+  margin: 0 5% 5% 5%;
+}
+
+.create-playlist-button {
+  margin: 1% !important;
+}
+
+.create-playlist-logo-container {
+  margin: auto;
+  width: fit-content;
+  color: #FCC201;
+  font-weight: bold;
+}
+
+.create-playlist-logo-container img {
+  vertical-align: middle;
+}
+
+.create-playlist-goldify-logo {
+  height: 100px;
+  margin: 15px;
+}
+
+.create-playlist-spotify-logo {
+  height: 70px;
+  margin: 20px;
+}
+
+@media only screen and (min-width: 600px) {
+  .create-playlist-wrapper {
+    width: 50%;
+  }
+}

--- a/src/css/GoldifyCreatePlaylist.css
+++ b/src/css/GoldifyCreatePlaylist.css
@@ -1,5 +1,5 @@
 .create-playlist-wrapper {
-  background-color: #0B162A;
+  background-color: #212121;
   padding: 10px;
   margin: 5% auto;
   box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.4);

--- a/src/css/UserInfo.css
+++ b/src/css/UserInfo.css
@@ -2,9 +2,6 @@
   cursor: pointer;
   display: flex;
   box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.4);
-  margin-bottom: 1%;
-  text-align: left;
-  width: fit-content;
   border-radius: 20px;
   background-color: #191414;
   border: 4px solid #1DB954;
@@ -69,4 +66,12 @@
 
 .spotify-logo img {
   height: 70px;
+}
+
+@media only screen and (min-width: 600px) {
+  .card {
+    margin-bottom: 1%;
+    text-align: left;
+    width: fit-content;
+  }
 }

--- a/src/js/solo/goldify-playlist/GoldifyCreatePlaylist.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyCreatePlaylist.jsx
@@ -35,11 +35,6 @@ class GoldifyCreatePlaylist extends Component {
   }
 
   /**
-   * Creates a goldify playlist once retrievedTokenData and userData are set
-   */
-  componentDidMount() {}
-
-  /**
    * Creates a goldify playlist for the user, since one was not found
    * @param  {object} retrievedTokenData User data containing an access_token
    * @param  {string} userId User's ID to create the playlist under

--- a/src/js/solo/goldify-playlist/GoldifyCreatePlaylist.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyCreatePlaylist.jsx
@@ -10,28 +10,34 @@ import { goldifyBase64 } from "../../../assets/goldifyBase64String";
 import {
   GOLDIFY_PLAYLIST_NAME,
   GOLDIFY_PLAYLIST_DESCRIPTION,
+  spotifyHomePageUrl,
 } from "../../utils/constants";
+import { green } from "@material-ui/core/colors";
+import Button from "@material-ui/core/Button";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import CheckIcon from "@material-ui/icons/Check";
+import Fab from "@material-ui/core/Fab";
+import "../../../css/GoldifyCreatePlaylist.css";
+import spotifyLogo from "../../../assets/spotify_logo.png";
+import goldifyLogo from "../../../assets/goldify_logo.png";
 
 class GoldifyCreatePlaylist extends Component {
   constructor(props) {
     // Initialize mutable state
     super(props);
+    this.state = {
+      loading: false,
+      success: false,
+      playlistCreated: false,
+    };
+    this.handleButtonClick = this.handleButtonClick.bind(this);
+    this.createNewGoldifyPlaylist = this.createNewGoldifyPlaylist.bind(this);
   }
 
   /**
    * Creates a goldify playlist once retrievedTokenData and userData are set
    */
-  componentDidMount() {
-    if (
-      !_.isEmpty(this.props.retrievedTokenData) &&
-      !_.isEmpty(this.props.userData)
-    ) {
-      this.createNewGoldifyPlaylist(
-        this.props.retrievedTokenData,
-        this.props.userData.id
-      );
-    }
-  }
+  componentDidMount() {}
 
   /**
    * Creates a goldify playlist for the user, since one was not found
@@ -51,10 +57,7 @@ class GoldifyCreatePlaylist extends Component {
           alert(`Unable to create your ${GOLDIFY_PLAYLIST_NAME} playlist.`);
           replaceWindowURL("/");
         } else {
-          alert(
-            `Congrats! Your ${GOLDIFY_PLAYLIST_NAME} playlist has been created.`
-          );
-          this.props.playlistUpdater(data);
+          this.handlePlaylistCreated(data);
           return data.id;
         }
       })
@@ -66,13 +69,98 @@ class GoldifyCreatePlaylist extends Component {
   }
 
   /**
+   * Calls the async function to create the Goldify playlist
+   */
+  createNewGoldifyPlaylistAction() {
+    this.createNewGoldifyPlaylist(
+      this.props.retrievedTokenData,
+      this.props.userData.id
+    );
+  }
+
+  /**
+   * Sets the state to loading, but no success. This way
+   * the loading animation displays until the playlist is created
+   */
+  handleButtonClick() {
+    if (!this.state.loading) {
+      this.setState({
+        loading: true,
+        success: false,
+      });
+      this.createNewGoldifyPlaylistAction();
+    }
+  }
+
+  /**
+   * Called after the playlist creation has completed
+   * @param  {object} data Playlist data retrieved after creation
+   * Then performs a loading and checkmark notification before
+   * loading the Goldify Solo page
+   */
+  handlePlaylistCreated(data) {
+    window.setTimeout(() => {
+      this.setState({
+        loading: false,
+        success: true,
+      });
+      window.setTimeout(() => {
+        this.props.playlistUpdater(data);
+      }, 1500);
+    }, 2000);
+  }
+
+  /**
    * Shows text telling the user that their playlist is being created
    * @returns {HTMLElement} Basic div with an h3 header
    */
   createPlaylistDiv() {
     return (
-      <div>
-        <h3>Creating Playlist...</h3>
+      <div className="create-playlist-wrapper">
+        <h1 className="create-playlist-header">Welcome to Goldify Solo!</h1>
+        <div className="create-playlist-logo-container">
+          <img
+            className="create-playlist-goldify-logo"
+            src={goldifyLogo}
+            alt="Goldify Logo"
+          />
+          X
+          <a href={spotifyHomePageUrl} target="_blank" rel="noreferrer">
+            <img
+              className="create-playlist-spotify-logo"
+              src={spotifyLogo}
+              alt="Spotify Logo"
+            />
+          </a>
+        </div>
+        <p className="create-playlist-body">
+          It looks like you don&apos;t have a Goldify Playlist yet. No worries,
+          we got you! Click the button below to create your Goldify Playlist and
+          build your very own golden playlist.
+        </p>
+        <div>
+          {this.state.success ? (
+            <Fab
+              aria-label="save"
+              color="primary"
+              style={{ background: green[500] }}
+            >
+              <CheckIcon />
+            </Fab>
+          ) : this.state.loading ? (
+            <CircularProgress size={56} color="primary" />
+          ) : (
+            <Button
+              className="create-playlist-button"
+              variant="contained"
+              color="primary"
+              disabled={this.state.loading}
+              onClick={this.handleButtonClick}
+            >
+              Create Goldify Playlist
+            </Button>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/js/solo/goldify-playlist/GoldifyPlaylist.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyPlaylist.jsx
@@ -53,9 +53,6 @@ class GoldifyPlaylist extends Component {
       GOLDIFY_PLAYLIST_NAME
     ).then((data) => {
       if (data === null) {
-        alert(
-          `You don't have a ${GOLDIFY_PLAYLIST_NAME} playlist! Let's create one for you.`
-        );
         this.setState({
           goldifyPlaylist: null,
         });


### PR DESCRIPTION
- Adds clean new popup when there is no Goldify Playlist found
- Popup contains brief statement informing the user to click a button to create their playlist
- they are given a checkmark animation so they know everything is all set and then are brought to the Solo page
- Of course, keeping it 💯  when it comes to test coverage (was a bit tough, learned a new trick for timeouts in jest)

Sorry for the late pull request. I really wanted to get this in before a snooze

Closes #58 