### PR TITLE
Removes Home tab from Goldify

### DIFF
--- a/src/__tests__/GoldifyApp.test.js
+++ b/src/__tests__/GoldifyApp.test.js
@@ -17,8 +17,8 @@ test("Goldify App has proper footer", () => {
 
 test("Confirm the Selected Tab is correct", () => {
   const wrapper = shallow(<GoldifyApp />);
-  expect(wrapper.instance().getSelectedTab(HOME_PAGE_PATH)).toEqual(0);
-  expect(wrapper.instance().getSelectedTab(SOLO_PAGE_PATH)).toEqual(1);
+  expect(wrapper.instance().getSelectedTab(HOME_PAGE_PATH)).toEqual(false);
+  expect(wrapper.instance().getSelectedTab(SOLO_PAGE_PATH)).toEqual(0);
 });
 
 test("Run Web Vitals", () => {

--- a/src/js/GoldifyApp.jsx
+++ b/src/js/GoldifyApp.jsx
@@ -31,7 +31,7 @@ class GoldifyApp extends Component {
    * @returns {Integer} The selected tab index
    */
   getSelectedTab(currentUrl) {
-    return currentUrl.indexOf(SOLO_PAGE_PATH) > -1 ? 1 : 0;
+    return currentUrl.indexOf(SOLO_PAGE_PATH) > -1 ? 0 : false;
   }
 
   /**
@@ -62,11 +62,6 @@ class GoldifyApp extends Component {
                   aria-label="icon label tabs example"
                   className="goldify-tabs"
                 >
-                  <Tab
-                    className="goldify-tab"
-                    label="Home"
-                    href={HOME_PAGE_PATH}
-                  />
                   <Tab
                     className="goldify-tab"
                     label="Solo"


### PR DESCRIPTION
- This removes the Home tab from Goldify
- Sets tab value to false to prevent "invalid value" errors with Material UI Tabs
- Updates test coverage to reflect these changes (💯 still of course)


Closes #61 