### PR TITLE
Adds background shadow border to track tables

### DIFF
--- a/src/css/TrackDataTable.css
+++ b/src/css/TrackDataTable.css
@@ -11,10 +11,18 @@
   max-width: 100%;
 }
 
-.track-data-table-inner-container {
+.track-data-table-outer-container {
   overflow-y: auto;
   height: 360px;
-  width: 100%;
+  width: calc(100% - 20px);
+  border-radius: 12px;
+  margin: 10px;
+  scroll-margin: 10px;
+  box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.4);
+}
+
+.track-data-table-inner-container {
+  overflow-x: scroll;
 }
 
 .track-data-table-inner-container thead th {
@@ -165,7 +173,7 @@
     float: none !important;
   }
 
-  .track-data-table-inner-container {
+  .track-data-table-outer-container {
     height: 630px;
   }
 

--- a/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
@@ -219,26 +219,28 @@ class GoldifyPlaylistData extends Component {
               </h1>
             </a>
           </div>
-          <div className="track-data-table-inner-container">
-            <table className="track-data-table">
-              <thead className="track-data-thead">
-                <tr className="track-data-tr">
-                  <th className="track-data-th"></th>
-                  <th className="track-data-th track-data-action-icon"></th>
-                  <th className="track-data-th track-data-album-cover">
-                    Album
-                  </th>
-                  <th className="track-data-th">Title</th>
-                  <th className="track-data-th">Artist(s)</th>
-                </tr>
-              </thead>
-              <SortableList
-                goldifyPlaylistData={this.state.goldifyPlaylistData}
-                removeTrackContainerHandler={this.removeGoldifyTrack}
-                onSortEnd={this.onSortEnd}
-                useDragHandle
-              />
-            </table>
+          <div className="track-data-table-outer-container">
+            <div className="track-data-table-inner-container">
+              <table className="track-data-table">
+                <thead className="track-data-thead">
+                  <tr className="track-data-tr">
+                    <th className="track-data-th"></th>
+                    <th className="track-data-th track-data-action-icon"></th>
+                    <th className="track-data-th track-data-album-cover">
+                      Album
+                    </th>
+                    <th className="track-data-th">Title</th>
+                    <th className="track-data-th">Artist(s)</th>
+                  </tr>
+                </thead>
+                <SortableList
+                  goldifyPlaylistData={this.state.goldifyPlaylistData}
+                  removeTrackContainerHandler={this.removeGoldifyTrack}
+                  onSortEnd={this.onSortEnd}
+                  useDragHandle
+                />
+              </table>
+            </div>
           </div>
         </div>
         <TopListeningData

--- a/src/js/solo/top-listens/TopListeningData.jsx
+++ b/src/js/solo/top-listens/TopListeningData.jsx
@@ -156,80 +156,82 @@ class TopListeningData extends Component {
             </Tabs>
           </Paper>
         </div>
-        <div className="track-data-table-inner-container">
-          <table className="track-data-table">
-            <thead className="track-data-thead">
-              <tr className="track-data-tr">
-                <th className="track-data-th"></th>
-                <th className="track-data-th">Album</th>
-                <th className="track-data-th">Title</th>
-                <th className="track-data-th">Artist(s)</th>
-              </tr>
-            </thead>
-            <tbody className="track-data-tbody">
-              {this.state.topListeningData.items.map((listValue, index) => {
-                return (
-                  <tr key={index} className="track-data-tr">
-                    <td className="track-data-td track-data-action-icon">
-                      {this.goldifyPlaylistContainsTrack(listValue.uri) ? (
-                        <BeenhereIcon
-                          style={{ color: blue[500] }}
-                          fontSize="large"
-                        />
-                      ) : (
-                        <AddCircleIcon
-                          className="top-listens-add-track"
-                          style={{ color: green[500] }}
-                          fontSize="large"
-                          onClick={() => {
-                            this.props.addTrackHandler(listValue);
-                          }}
-                        />
-                      )}
-                    </td>
-                    <td className="track-data-td track-data-album-cover">
-                      <a
-                        href={getSpotifyRedirectURL(
-                          "album",
-                          listValue.album.id
+        <div className="track-data-table-outer-container">
+          <div className="track-data-table-inner-container">
+            <table className="track-data-table">
+              <thead className="track-data-thead">
+                <tr className="track-data-tr">
+                  <th className="track-data-th"></th>
+                  <th className="track-data-th">Album</th>
+                  <th className="track-data-th">Title</th>
+                  <th className="track-data-th">Artist(s)</th>
+                </tr>
+              </thead>
+              <tbody className="track-data-tbody">
+                {this.state.topListeningData.items.map((listValue, index) => {
+                  return (
+                    <tr key={index} className="track-data-tr">
+                      <td className="track-data-td track-data-action-icon">
+                        {this.goldifyPlaylistContainsTrack(listValue.uri) ? (
+                          <BeenhereIcon
+                            style={{ color: blue[500] }}
+                            fontSize="large"
+                          />
+                        ) : (
+                          <AddCircleIcon
+                            className="top-listens-add-track"
+                            style={{ color: green[500] }}
+                            fontSize="large"
+                            onClick={() => {
+                              this.props.addTrackHandler(listValue);
+                            }}
+                          />
                         )}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        <img
-                          alt={listValue.album.name}
-                          src={listValue.album.images[0].url}
-                        />
-                      </a>
-                    </td>
-                    <td className="track-data-td">
-                      <a
-                        href={getSpotifyRedirectURL("track", listValue.id)}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        {listValue.name}
-                      </a>
-                    </td>
-                    <td className="track-data-td">
-                      {listValue.album.artists
-                        .map((artist, index) => (
-                          <a
-                            key={index}
-                            href={getSpotifyRedirectURL("artist", artist.id)}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            {artist.name}
-                          </a>
-                        ))
-                        .reduce((prev, curr) => [prev, ", ", curr])}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                      </td>
+                      <td className="track-data-td track-data-album-cover">
+                        <a
+                          href={getSpotifyRedirectURL(
+                            "album",
+                            listValue.album.id
+                          )}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          <img
+                            alt={listValue.album.name}
+                            src={listValue.album.images[0].url}
+                          />
+                        </a>
+                      </td>
+                      <td className="track-data-td">
+                        <a
+                          href={getSpotifyRedirectURL("track", listValue.id)}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {listValue.name}
+                        </a>
+                      </td>
+                      <td className="track-data-td">
+                        {listValue.album.artists
+                          .map((artist, index) => (
+                            <a
+                              key={index}
+                              href={getSpotifyRedirectURL("artist", artist.id)}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {artist.name}
+                            </a>
+                          ))
+                          .reduce((prev, curr) => [prev, ", ", curr])}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
- Adds background shadow border to track tables
- Emulates a border without adding padding (which caused more issue than not)
- Adds the same styling to both the Goldify playlist and Top Hits tables
- Keeps coverage at 💯 


Closes #62 