### PR TITLE
Adds Material UI drop down for time range and alters term names

### DIFF
--- a/src/__tests__/solo/top-listens/TopListeningData.test.js
+++ b/src/__tests__/solo/top-listens/TopListeningData.test.js
@@ -263,14 +263,14 @@ test("Confirm updateTopListeningDataTerm updates the top listens term", () => {
   };
   wrapper.instance().setState = jest.fn();
 
-  wrapper.instance().updateTopListeningDataTerm({}, 0);
+  wrapper.instance().updateTopListeningDataTerm({ target: { value: 0 } });
   expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
   expect(wrapper.instance().setState).toHaveBeenCalledWith({
     selectedTerm: 0,
     topListeningData: topListeningDataFixtures.getTopListeningData().short_term,
   });
 
-  wrapper.instance().updateTopListeningDataTerm({}, 1);
+  wrapper.instance().updateTopListeningDataTerm({ target: { value: 1 } });
   expect(wrapper.instance().setState).toHaveBeenCalledTimes(2);
   expect(wrapper.instance().setState).toHaveBeenCalledWith({
     selectedTerm: 1,
@@ -278,7 +278,7 @@ test("Confirm updateTopListeningDataTerm updates the top listens term", () => {
       .medium_term,
   });
 
-  wrapper.instance().updateTopListeningDataTerm({}, 2);
+  wrapper.instance().updateTopListeningDataTerm({ target: { value: 2 } });
   expect(wrapper.instance().setState).toHaveBeenCalledTimes(3);
   expect(wrapper.instance().setState).toHaveBeenCalledWith({
     selectedTerm: 1,
@@ -287,9 +287,9 @@ test("Confirm updateTopListeningDataTerm updates the top listens term", () => {
 
   let errorThrown = false;
   try {
-    wrapper.instance().updateTopListeningDataTerm({}, undefined);
+    wrapper.instance().updateTopListeningDataTerm(undefined);
   } catch (err) {
-    expect(err).toEqual(Error("Value cannot be undefined: {}"));
+    expect(err).toEqual(Error("Event cannot be undefined"));
     errorThrown = true;
   }
   expect(errorThrown);

--- a/src/css/GoldifyApp.css
+++ b/src/css/GoldifyApp.css
@@ -90,7 +90,7 @@
   height: 40px;
   color: white;
   background-color: #212121;
-  z-index: 30000;
+  z-index: 3000;
   overflow: hidden;
 }
 

--- a/src/css/GoldifySoloPage.css
+++ b/src/css/GoldifySoloPage.css
@@ -14,5 +14,5 @@ button:hover {
 }
 
 .notification-snack-bar {
-  z-index: 10047 !important;
+  z-index: 1047 !important;
 }

--- a/src/css/TrackDataTable.css
+++ b/src/css/TrackDataTable.css
@@ -20,7 +20,7 @@
 .track-data-table-inner-container thead th {
   position: sticky;
   top: 0;
-  z-index: 10001;
+  z-index: 1001;
 }
 
 .track-data-table-header {
@@ -31,14 +31,14 @@
 }
 
 .track-data-table-tab-panel {
-  display: block;
   float: right;
+  margin: 5px 0 !important;
 }
 
 .track-data-table-header-container {
   left: 0;
   position: sticky;
-  z-index: 9999;
+  z-index: 999;
   margin: auto;
 }
 
@@ -61,14 +61,14 @@
   width: 100px;
   left: 0;
   position: sticky;
-  z-index: 9999;
+  z-index: 999;
 }
 
 .track-data-action-icon {
   width: 10px;
   left: 0;
   position: sticky;
-  z-index: 9999;
+  z-index: 999;
 }
 
 .track-data-td img {
@@ -113,7 +113,7 @@
 .goldify-update-buttons {
   top: 0;
   position: sticky;
-  z-index: 10002;
+  z-index: 1002;
   display: block;
   height: 36px;
   margin: auto;

--- a/src/js/solo/top-listens/TopListeningData.jsx
+++ b/src/js/solo/top-listens/TopListeningData.jsx
@@ -16,9 +16,10 @@ import {
   longTermTracksRecommended,
 } from "../../utils/constants";
 
-import Paper from "@material-ui/core/Paper";
-import Tabs from "@material-ui/core/Tabs";
-import Tab from "@material-ui/core/Tab";
+import FormControl from "@material-ui/core/FormControl";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
 
 class TopListeningData extends Component {
   newlyCreatedPlaylist = this.props.newlyCreatedPlaylist;
@@ -82,10 +83,11 @@ class TopListeningData extends Component {
    * @param  {number} newValue The value of the tab selected
    * @throws {Error} If the event was not defined
    */
-  updateTopListeningDataTerm(event, newValue) {
-    if (newValue === undefined) {
-      throw Error("Value cannot be undefined: " + JSON.stringify(event));
+  updateTopListeningDataTerm(event) {
+    if (event === undefined) {
+      throw Error("Event cannot be undefined");
     }
+    let newValue = event.target.value;
     let newListeningData;
     switch (newValue) {
       case 0:
@@ -141,20 +143,23 @@ class TopListeningData extends Component {
       <div className="track-data-table-container top-listens-table-container">
         <div className="track-data-table-header-container">
           <h1 className="track-data-table-header">Your Top Hits</h1>
-          <Paper square className="track-data-table-tab-panel">
-            <Tabs
+          <FormControl
+            variant="outlined"
+            className="track-data-table-tab-panel"
+          >
+            <InputLabel id="demo-simple-select-outlined-label">
+              Time Range
+            </InputLabel>
+            <Select
               value={this.state.selectedTerm}
               onChange={this.updateTopListeningDataTerm}
-              variant="fullWidth"
-              indicatorColor="primary"
-              textColor="primary"
-              aria-label="icon label tabs example"
+              label="Time Range"
             >
-              <Tab label="Short Term" />
-              <Tab label="Medium Term" />
-              <Tab label="Long Term" />
-            </Tabs>
-          </Paper>
+              <MenuItem value={0}>Recent</MenuItem>
+              <MenuItem value={1}>Recurring</MenuItem>
+              <MenuItem value={2}>Everlasting</MenuItem>
+            </Select>
+          </FormControl>
         </div>
         <div className="track-data-table-inner-container">
           <table className="track-data-table">


### PR DESCRIPTION
- Adds Material UI drop down for time range and alters term names
- Fixes issue with mobile where small phones would experience a weird UI layout
- Alters the Short/Medium/Long Term trio of phrasing to be more "cool"?
- Updates test coverage to be consistent with the other changes in this PR, keeping everything 💯 

Closes #64 AND Closes #57