### PR TITLE
Adds new tab for Recently Removed songs

### DIFF
--- a/src/__tests__/solo/goldify-playlist/GoldifyPlaylistData.test.js
+++ b/src/__tests__/solo/goldify-playlist/GoldifyPlaylistData.test.js
@@ -226,6 +226,51 @@ test("Confirm cancelUpdatesToGoldifyPlaylist cancels any updates", () => {
   expect(wrapper.instance().setState).toHaveBeenCalledWith({
     goldifyPlaylistData: getPlaylistTracksData(),
     playlistDirty: false,
+    removedTrackDataMap: new Map(),
+  });
+});
+
+test("Confirm cancelUpdatesToGoldifyPlaylist cleans removed tracks", () => {
+  const wrapper = goldifyPlaylistDataWrapper();
+  wrapper.instance().setURIListFromPlaylistData = jest.fn();
+  wrapper.instance().setSavedGoldifyPlaylistData = jest.fn();
+  wrapper.instance().setState = jest.fn();
+
+  let testRemovedTrackDataMap = new Map();
+  let expectedFinalRemovedTrackDataMap = new Map();
+  testRemovedTrackDataMap.set(
+    getPlaylistTracksData()[0].track.uri,
+    getPlaylistTracksData()[0]
+  );
+  testRemovedTrackDataMap.set(
+    getPlaylistTracksData()[1].track.uri,
+    getPlaylistTracksData()[1]
+  );
+  expectedFinalRemovedTrackDataMap.set(
+    getPlaylistTracksData()[0].track.uri,
+    getPlaylistTracksData()[0]
+  );
+  let testPlaylistTracksData = getPlaylistTracksData();
+  testPlaylistTracksData.splice(0, 2);
+
+  wrapper.instance().goldifyPlaylistTrackUriList = [
+    getPlaylistTracksData()[1].track.uri,
+  ];
+  wrapper.instance().savedGoldifyPlaylistData = getPlaylistTracksData().splice(
+    0,
+    1
+  );
+  wrapper.instance().state = {
+    removedTrackDataMap: testRemovedTrackDataMap,
+    goldifyPlaylistData: testPlaylistTracksData,
+  };
+  wrapper.instance().cancelUpdatesToGoldifyPlaylist();
+
+  expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().setState).toHaveBeenCalledWith({
+    goldifyPlaylistData: getPlaylistTracksData().splice(0, 1),
+    playlistDirty: false,
+    removedTrackDataMap: expectedFinalRemovedTrackDataMap,
   });
 });
 
@@ -364,9 +409,7 @@ test("Expect updateGoldifyPlaylist to clean re-added removed tracks", () => {
     getPlaylistTracksData()[1]
   );
   let testPlaylistTracksData = getPlaylistTracksData();
-  console.log(testPlaylistTracksData);
   testPlaylistTracksData.splice(0, 1);
-  console.log(testPlaylistTracksData);
 
   wrapper.instance().goldifyPlaylistTrackUriList = [
     getPlaylistTracksData()[0].track.uri,

--- a/src/__tests__/solo/goldify-playlist/GoldifyPlaylistData.test.js
+++ b/src/__tests__/solo/goldify-playlist/GoldifyPlaylistData.test.js
@@ -301,23 +301,50 @@ test("Confirm addTrackFromTopListensData adds track", () => {
   ]);
 });
 
-test("Confirm removeGoldifyTrack removes the track", () => {
+test("Confirm removeGoldifyTrack removes correctly", () => {
   const wrapper = goldifyPlaylistDataWrapper();
   wrapper.instance().setState = jest.fn();
   wrapper.instance().removeGoldifyPlaylistTrackUri = jest.fn();
+  // Run remove with saved track
   wrapper.instance().state.goldifyPlaylistData = getPlaylistTracksData();
-  wrapper
-    .instance()
-    .removeGoldifyTrack(
-      playlistTracksFixtures.testTrack("TEST_NAME", "TEST_SONG_ID_1").track
-    );
+  wrapper.instance().state.removedTrackDataMap = new Map();
+  wrapper.instance().savedGoldifyPlaylistData = getPlaylistTracksData();
+  let expectedGoldifyPlaylistData = getPlaylistTracksData();
+  let removedTrack = expectedGoldifyPlaylistData.splice(0, 1)[0];
+  let expectedRemovedTrackMap = new Map();
+  expectedRemovedTrackMap.set(removedTrack.track.uri, removedTrack.track);
+  wrapper.instance().removeGoldifyTrack(removedTrack.track);
   expect(
     wrapper.instance().removeGoldifyPlaylistTrackUri
   ).toHaveBeenCalledTimes(1);
   expect(wrapper.instance().removeGoldifyPlaylistTrackUri).toHaveBeenCalledWith(
-    playlistTracksFixtures.testTrack("TEST_NAME", "TEST_SONG_ID_1").track.uri
+    removedTrack.track.uri
   );
   expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().setState).toHaveBeenCalledWith({
+    goldifyPlaylistData: expectedGoldifyPlaylistData,
+    playlistDirty: true,
+    removedTrackDataMap: expectedRemovedTrackMap,
+  });
+  // Run remove with recently added (but not saved) track
+  wrapper.instance().state.goldifyPlaylistData = getPlaylistTracksData();
+  wrapper.instance().state.removedTrackDataMap = new Map();
+  wrapper.instance().savedGoldifyPlaylistData = [];
+  expectedGoldifyPlaylistData = getPlaylistTracksData();
+  expectedGoldifyPlaylistData.splice(0, 1)[0];
+  wrapper.instance().removeGoldifyTrack(removedTrack.track);
+  expect(
+    wrapper.instance().removeGoldifyPlaylistTrackUri
+  ).toHaveBeenCalledTimes(2);
+  expect(wrapper.instance().removeGoldifyPlaylistTrackUri).toHaveBeenCalledWith(
+    removedTrack.track.uri
+  );
+  expect(wrapper.instance().setState).toHaveBeenCalledTimes(2);
+  expect(wrapper.instance().setState).toHaveBeenCalledWith({
+    goldifyPlaylistData: expectedGoldifyPlaylistData,
+    playlistDirty: true,
+    removedTrackDataMap: new Map(),
+  });
 
   let errorThrown = false;
   try {

--- a/src/__tests__/solo/goldify-playlist/GoldifyPlaylistData.test.js
+++ b/src/__tests__/solo/goldify-playlist/GoldifyPlaylistData.test.js
@@ -211,6 +211,7 @@ test("Confirm updateGoldifyPlaylist updates goldify playlist", () => {
   expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
   expect(wrapper.instance().setState).toHaveBeenCalledWith({
     playlistDirty: false,
+    removedTrackDataMap: new Map(),
   });
 });
 
@@ -323,6 +324,64 @@ test("Expect onSortEnd to call setState", () => {
   wrapper.instance().setState = jest.fn();
   wrapper.instance().onSortEnd(0, 1, getPlaylistTracksData());
   expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
+});
+
+test("Expect getRemovedTrackData() to return proper data", () => {
+  const wrapper = goldifyPlaylistDataWrapper();
+
+  expect(wrapper.instance().getRemovedTrackData()).toEqual({ items: [] });
+  let testRemovedTrackDataMap = new Map();
+  testRemovedTrackDataMap.set(
+    getPlaylistTracksData()[0].uri,
+    getPlaylistTracksData()[0]
+  );
+  wrapper.instance().state = {
+    removedTrackDataMap: testRemovedTrackDataMap,
+  };
+  expect(wrapper.instance().getRemovedTrackData()).toEqual({
+    items: [getPlaylistTracksData()[0]],
+  });
+});
+
+test("Expect updateGoldifyPlaylist to clean re-added removed tracks", () => {
+  const wrapper = goldifyPlaylistDataWrapper();
+  wrapper.instance().setURIListFromPlaylistData = jest.fn();
+  wrapper.instance().setSavedGoldifyPlaylistData = jest.fn();
+  wrapper.instance().setState = jest.fn();
+
+  let testRemovedTrackDataMap = new Map();
+  let expectedFinalRemovedTrackDataMap = new Map();
+  testRemovedTrackDataMap.set(
+    getPlaylistTracksData()[0].track.uri,
+    getPlaylistTracksData()[0]
+  );
+  testRemovedTrackDataMap.set(
+    getPlaylistTracksData()[1].track.uri,
+    getPlaylistTracksData()[1]
+  );
+  expectedFinalRemovedTrackDataMap.set(
+    getPlaylistTracksData()[1].track.uri,
+    getPlaylistTracksData()[1]
+  );
+  let testPlaylistTracksData = getPlaylistTracksData();
+  console.log(testPlaylistTracksData);
+  testPlaylistTracksData.splice(0, 1);
+  console.log(testPlaylistTracksData);
+
+  wrapper.instance().goldifyPlaylistTrackUriList = [
+    getPlaylistTracksData()[0].track.uri,
+  ];
+  wrapper.instance().state = {
+    removedTrackDataMap: testRemovedTrackDataMap,
+    goldifyPlaylistData: testPlaylistTracksData,
+  };
+  wrapper.instance().updateGoldifyPlaylist();
+
+  expect(wrapper.instance().setState).toHaveBeenCalledTimes(1);
+  expect(wrapper.instance().setState).toHaveBeenCalledWith({
+    playlistDirty: false,
+    removedTrackDataMap: expectedFinalRemovedTrackDataMap,
+  });
 });
 
 test("Use ReactDOM Render to render the SortableList", () => {

--- a/src/__tests__/solo/top-listens/TopListeningData.test.js
+++ b/src/__tests__/solo/top-listens/TopListeningData.test.js
@@ -32,33 +32,19 @@ configure({ adapter: new Adapter() });
 const goldifySoloFixtures = require("../../../__fixtures__/GoldifySoloFixtures");
 const topListeningDataFixtures = require("../../../__fixtures__/TopListeningDataFixtures");
 
-const getTopListeningDataWrapper = () => {
+const getTopListeningDataWrapper = (
+  removedTrackDataRetVal = { items: [] },
+  trackListRetValue = [topListeningDataFixtures.testUri]
+) => {
   return shallow(
     <TopListeningData
       retrievedTokenData={{}}
-      goldifyUriList={[topListeningDataFixtures.testUri]}
+      goldifyUriList={trackListRetValue}
       addTrackHandler={jest.fn()}
       playlistDirty={false}
       newlyCreatedPlaylist={false}
       onAutoFillCompleteHandler={jest.fn()}
-      getRemovedTrackData={jest
-        .fn()
-        .mockReturnValue(
-          topListeningDataFixtures.getTopListeningData().long_term
-        )}
-    />
-  );
-};
-
-const getTopListeningDataWrapperEmptyPlaylist = () => {
-  return shallow(
-    <TopListeningData
-      retrievedTokenData={{}}
-      goldifyUriList={[]}
-      addTrackHandler={jest.fn()}
-      playlistDirty={false}
-      newlyCreatedPlaylist={false}
-      onAutoFillCompleteHandler={jest.fn()}
+      getRemovedTrackData={jest.fn().mockReturnValue(removedTrackDataRetVal)}
     />
   );
 };
@@ -177,7 +163,7 @@ test("Check for which div is loaded on render for TopListeningData", () => {
 });
 
 test("Check that empty playlists are automatically given recommendations", () => {
-  const wrapper = getTopListeningDataWrapperEmptyPlaylist();
+  const wrapper = getTopListeningDataWrapper({ items: [] }, []);
   wrapper.instance().getTopListeningDataDiv = jest
     .fn()
     .mockReturnValue("Top Listens Table!");
@@ -196,7 +182,7 @@ test("Check that empty playlists are automatically given recommendations", () =>
 });
 
 test("Feed autoFillGoldifyPlaylist empty data and expect no callouts", () => {
-  const wrapper = getTopListeningDataWrapperEmptyPlaylist();
+  const wrapper = getTopListeningDataWrapper({ items: [] }, []);
   wrapper.instance().state.shortTermListeningData = {
     items: [],
   };
@@ -211,7 +197,7 @@ test("Feed autoFillGoldifyPlaylist empty data and expect no callouts", () => {
 });
 
 test("Check that empty playlists are not given tracks if top listening data wasn't retrieved", () => {
-  const wrapper = getTopListeningDataWrapperEmptyPlaylist();
+  const wrapper = getTopListeningDataWrapper({ items: [] }, []);
   wrapper.instance().getTopListeningDataDiv = jest
     .fn()
     .mockReturnValue("Top Listens Table!");
@@ -259,7 +245,9 @@ test("Expect add handler called on AddCircleIcon button", () => {
 });
 
 test("Confirm updateTopListeningDataTerm updates the top listens term", () => {
-  const wrapper = getTopListeningDataWrapper();
+  const wrapper = getTopListeningDataWrapper(
+    topListeningDataFixtures.getTopListeningData().long_term
+  );
   wrapper.instance().state = {
     selectedTerm: 0,
     topListeningData: topListeningDataFixtures.getTopListeningData().short_term,
@@ -320,7 +308,9 @@ test("Confirm updateTopListeningDataTerm updates the top listens term", () => {
 });
 
 test("Expect getRemovedTrackData() called only for Recently Removed", () => {
-  const wrapper = getTopListeningDataWrapper();
+  const wrapper = getTopListeningDataWrapper(
+    topListeningDataFixtures.getTopListeningData().long_term
+  );
   wrapper.instance().getTopListeningDataItemDiv = jest.fn();
   wrapper.instance().render = jest.fn();
   let NUM_LONG_TERM_ITEMS = topListeningDataFixtures.getTopListeningData()

--- a/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
@@ -39,6 +39,7 @@ class GoldifyPlaylistData extends Component {
     this.removeGoldifyTrack = this.removeGoldifyTrack.bind(this);
     this.onSortEnd = this.onSortEnd.bind(this);
     this.getRemovedTrackData = this.getRemovedTrackData.bind(this);
+    this.inSavedGoldifyPlaylist = this.inSavedGoldifyPlaylist.bind(this);
   }
 
   /**
@@ -155,6 +156,12 @@ class GoldifyPlaylistData extends Component {
     }
   }
 
+  inSavedGoldifyPlaylist(removedTrack) {
+    return this.savedGoldifyPlaylistData.some((savedTrack) => {
+      return savedTrack.track.uri == removedTrack.track.uri;
+    });
+  }
+
   removeGoldifyTrack(track) {
     let currentPlaylistData = this.state.goldifyPlaylistData;
     let index = -1;
@@ -168,10 +175,12 @@ class GoldifyPlaylistData extends Component {
       this.removeGoldifyPlaylistTrackUri(track.uri);
       let removedTrack = currentPlaylistData.splice(index, 1);
       let curRemovedTrackDataMap = this.state.removedTrackDataMap;
-      curRemovedTrackDataMap.set(
-        removedTrack[0].track.uri,
-        removedTrack[0].track
-      );
+      if (this.inSavedGoldifyPlaylist(removedTrack[0])) {
+        curRemovedTrackDataMap.set(
+          removedTrack[0].track.uri,
+          removedTrack[0].track
+        );
+      }
       this.setState({
         goldifyPlaylistData: currentPlaylistData,
         playlistDirty: true,

--- a/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
@@ -127,9 +127,16 @@ class GoldifyPlaylistData extends Component {
 
   cancelUpdatesToGoldifyPlaylist() {
     this.setURIListFromPlaylistData(this.savedGoldifyPlaylistData);
+    let newRemovedTrackDataMap = this.state.removedTrackDataMap;
+    for (const uriKey of newRemovedTrackDataMap.keys()) {
+      if (this.goldifyPlaylistTrackUriList.includes(uriKey)) {
+        newRemovedTrackDataMap.delete(uriKey);
+      }
+    }
     this.setState({
       goldifyPlaylistData: this.savedGoldifyPlaylistData,
       playlistDirty: false,
+      removedTrackDataMap: newRemovedTrackDataMap,
     });
     this.setSavedGoldifyPlaylistData(this.savedGoldifyPlaylistData);
   }

--- a/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
@@ -112,8 +112,15 @@ class GoldifyPlaylistData extends Component {
       this.props.goldifyPlaylistId,
       this.goldifyPlaylistTrackUriList
     );
+    let newRemovedTrackDataMap = this.state.removedTrackDataMap;
+    for (const uriKey of newRemovedTrackDataMap.keys()) {
+      if (this.goldifyPlaylistTrackUriList.includes(uriKey)) {
+        newRemovedTrackDataMap.delete(uriKey);
+      }
+    }
     this.setState({
       playlistDirty: false,
+      removedTrackDataMap: newRemovedTrackDataMap,
     });
     this.setSavedGoldifyPlaylistData(this.state.goldifyPlaylistData);
   }
@@ -155,7 +162,7 @@ class GoldifyPlaylistData extends Component {
       let removedTrack = currentPlaylistData.splice(index, 1);
       let curRemovedTrackDataMap = this.state.removedTrackDataMap;
       curRemovedTrackDataMap.set(
-        removedTrack[0].track.id,
+        removedTrack[0].track.uri,
         removedTrack[0].track
       );
       this.setState({
@@ -184,7 +191,6 @@ class GoldifyPlaylistData extends Component {
    * @returns {HTMLElement} JSON data containing the removed tracks data
    */
   getRemovedTrackData() {
-    console.log("TIME TO DO THIS THING");
     let removedTrackData = { items: [] };
     for (const removedTrackDatum of this.state.removedTrackDataMap.values()) {
       removedTrackData.items.push(removedTrackDatum);
@@ -193,7 +199,6 @@ class GoldifyPlaylistData extends Component {
   }
 
   getGoldifyPlaylistDiv() {
-    console.log("TIME TO DO THIS THING1");
     return (
       <div>
         <div className="goldify-update-buttons">

--- a/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
+++ b/src/js/solo/goldify-playlist/GoldifyPlaylistData.jsx
@@ -23,6 +23,7 @@ class GoldifyPlaylistData extends Component {
     this.state = {
       goldifyPlaylistData: null,
       playlistDirty: false,
+      removedTrackDataMap: new Map(),
     };
 
     this.retrieveGoldifyPlaylistData = this.retrieveGoldifyPlaylistData.bind(
@@ -37,6 +38,7 @@ class GoldifyPlaylistData extends Component {
     );
     this.removeGoldifyTrack = this.removeGoldifyTrack.bind(this);
     this.onSortEnd = this.onSortEnd.bind(this);
+    this.getRemovedTrackData = this.getRemovedTrackData.bind(this);
   }
 
   /**
@@ -150,10 +152,16 @@ class GoldifyPlaylistData extends Component {
     }
     if (index !== -1) {
       this.removeGoldifyPlaylistTrackUri(track.uri);
-      currentPlaylistData.splice(index, 1);
+      let removedTrack = currentPlaylistData.splice(index, 1);
+      let curRemovedTrackDataMap = this.state.removedTrackDataMap;
+      curRemovedTrackDataMap.set(
+        removedTrack[0].track.id,
+        removedTrack[0].track
+      );
       this.setState({
         goldifyPlaylistData: currentPlaylistData,
         playlistDirty: true,
+        removedTrackDataMap: curRemovedTrackDataMap,
       });
     } else {
       throw Error("Track not found: " + track.id);
@@ -171,7 +179,21 @@ class GoldifyPlaylistData extends Component {
     });
   }
 
+  /**
+   * Gets the removedTrackData for this session.
+   * @returns {HTMLElement} JSON data containing the removed tracks data
+   */
+  getRemovedTrackData() {
+    console.log("TIME TO DO THIS THING");
+    let removedTrackData = { items: [] };
+    for (const removedTrackDatum of this.state.removedTrackDataMap.values()) {
+      removedTrackData.items.push(removedTrackDatum);
+    }
+    return removedTrackData;
+  }
+
   getGoldifyPlaylistDiv() {
+    console.log("TIME TO DO THIS THING1");
     return (
       <div>
         <div className="goldify-update-buttons">
@@ -250,6 +272,7 @@ class GoldifyPlaylistData extends Component {
           playlistDirty={this.state.playlistDirty}
           newlyCreatedPlaylist={this.props.newlyCreatedPlaylist}
           onAutoFillCompleteHandler={this.props.autoFillCompletedHandler}
+          getRemovedTrackData={this.getRemovedTrackData}
         />
       </div>
     );

--- a/src/js/solo/top-listens/TopListeningData.jsx
+++ b/src/js/solo/top-listens/TopListeningData.jsx
@@ -37,6 +37,9 @@ class TopListeningData extends Component {
     this.updateTopListeningDataTerm = this.updateTopListeningDataTerm.bind(
       this
     );
+    this.updateTopListeningDataTermOnChange = this.updateTopListeningDataTermOnChange.bind(
+      this
+    );
   }
 
   /**
@@ -78,18 +81,27 @@ class TopListeningData extends Component {
   }
 
   /**
-   * Changes which TopListeningData is visible and sets states accordingly
+   * Wrapper to updateTopListeningDataTerm for onChange event
    * @param  {object} event The OnChange event that triggered this call
    * @param  {number} newValue The value of the tab selected
    * @throws {Error} If the event was not defined
    */
-  updateTopListeningDataTerm(event) {
+  updateTopListeningDataTermOnChange(event) {
     if (event === undefined) {
       throw Error("Event cannot be undefined");
     }
-    let newValue = event.target.value;
+    this.updateTopListeningDataTerm(event.target.value);
+  }
+
+  /**
+   * Changes which TopListeningData is visible and sets states accordingly
+   * @param  {object} event The OnChange event that triggered this call
+   * @param  {number} value The value of the tab selected
+   * @throws {Error} If the event was not defined
+   */
+  updateTopListeningDataTerm(value) {
     let newListeningData;
-    switch (newValue) {
+    switch (value) {
       case 0:
         newListeningData = this.state.shortTermListeningData;
         break;
@@ -99,9 +111,12 @@ class TopListeningData extends Component {
       case 2:
         newListeningData = this.state.longTermListeningData;
         break;
+      case 3:
+        newListeningData = this.props.getRemovedTrackData();
+        break;
     }
     this.setState({
-      selectedTerm: newValue,
+      selectedTerm: value,
       topListeningData: newListeningData,
     });
   }
@@ -139,6 +154,8 @@ class TopListeningData extends Component {
    * @returns {HTMLElement} A div containing the retrieved/visible topListeningData
    */
   getTopListeningDataDiv() {
+    console.log("TIME TO DO THIS THING2");
+    this.updateTopListeningDataTerm(this.selectedTerm);
     return (
       <div className="track-data-table-container top-listens-table-container">
         <div className="track-data-table-header-container">
@@ -152,12 +169,13 @@ class TopListeningData extends Component {
             </InputLabel>
             <Select
               value={this.state.selectedTerm}
-              onChange={this.updateTopListeningDataTerm}
+              onChange={this.updateTopListeningDataTermOnChange}
               label="Time Range"
             >
               <MenuItem value={0}>Recent</MenuItem>
               <MenuItem value={1}>Recurring</MenuItem>
               <MenuItem value={2}>Everlasting</MenuItem>
+              <MenuItem value={3}>Recently Removed</MenuItem>
             </Select>
           </FormControl>
         </div>
@@ -271,6 +289,7 @@ TopListeningData.propTypes = {
   playlistDirty: PropTypes.bool.isRequired,
   newlyCreatedPlaylist: PropTypes.bool.isRequired,
   onAutoFillCompleteHandler: PropTypes.func.isRequired,
+  getRemovedTrackData: PropTypes.func.isRequired,
 };
 
 export default TopListeningData;

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -9,3 +9,7 @@ export const longTermTracksRecommended = 2;
 export const spotifyWebPlayerDomain = "https://open.spotify.com";
 export const spotifyHomePageUrl = "https://www.spotify.com/";
 export const goldifyGitHubUrl = "https://github.com/Goldify/Goldify";
+export const RECENT_TAB_VALUE = 0;
+export const RECURRING_TAB_VALUE = 1;
+export const EVERLASTING_TAB_VALUE = 2;
+export const RECENTLY_REMOVED_TAB_VALUE = 3;


### PR DESCRIPTION
- Adds new tab for Recently Removed songs
- This tab is after "Everlasting"
- Empty on page load
- Keeps test coverage at 💯  with some new tests

I would say you should check out the feature on your local machine. It's a bit wonky, but the communicating between the GoldifyPlaylistData and TopListeningData components here was a bit tough. I think I've cracked it, but I'm curious how you view this.

Closes #35 