### PR TITLE
Use default goldify logo if no user profile picture

### DIFF
--- a/src/__tests__/solo/user-info/UserInfo.test.js
+++ b/src/__tests__/solo/user-info/UserInfo.test.js
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom";
 import { configure, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import UserInfo from "../../../js/solo/user-info/UserInfo";
+import goldifyLogo from "../../../assets/goldify_logo.png";
 
 jest.mock("../../../js/utils/GoldifySoloUtils", () => ({
   replaceWindowURL: jest.fn(),
@@ -69,4 +70,13 @@ test("Confirm openUserSpotifyProfile opens a new tab with the User's Profile", (
     userInfoFixtures.testUserExternalUrlSpotify,
     "_blank"
   );
+});
+
+test("Check that default image is displayed if user has no profile picture", () => {
+  let userDataNoImage = userInfoFixtures.getUserTestData();
+  userDataNoImage.images = [];
+  const wrapper = shallow(<UserInfo userData={userDataNoImage} />);
+  let userInfoDivString = JSON.stringify(wrapper.instance().getUserInfoDiv());
+  expect(userInfoDivString).toContain(goldifyLogo);
+  expect(userInfoDivString).toContain(userInfoFixtures.testUserDisplayName);
 });

--- a/src/js/solo/user-info/UserInfo.jsx
+++ b/src/js/solo/user-info/UserInfo.jsx
@@ -3,6 +3,7 @@ import "../../../css/UserInfo.css";
 import PropTypes from "prop-types";
 import _ from "lodash";
 import spotifyLogo from "../../../assets/spotify_logo.png";
+import goldifyLogo from "../../../assets/goldify_logo.png";
 import Avatar from "@material-ui/core/Avatar";
 
 class UserInfo extends Component {
@@ -28,6 +29,10 @@ class UserInfo extends Component {
    * @param   {object} userData Object containing the user's profile data
    */
   async setUserData(userData) {
+    // If the user has no profile image, use the goldify image
+    if (userData.images.length == 0) {
+      userData.images.push({ url: goldifyLogo });
+    }
     this.setState({
       userData: userData,
     });


### PR DESCRIPTION
Fixes a bug where the app crashes when the user doesn't have a profile picture.

And of course, you know i like to keep it 💯 

Closes #77 